### PR TITLE
moonLandingWrapper is wrapped to Short not Integer

### DIFF
--- a/src/edu/matkosoric/operators/wrapper/and/primitive/ArmstrongAndDarwin.java
+++ b/src/edu/matkosoric/operators/wrapper/and/primitive/ArmstrongAndDarwin.java
@@ -17,7 +17,7 @@ public class ArmstrongAndDarwin {
         // because wrapper is unboxed
 
         System.out.println(moonLandingWrapper.equals(moonLandingPrimitive));    // false
-        // because primitive is autoboxed from short to Integer wrapper,
+        // because primitive is autoboxed from short to Short wrapper,
         // and comparing different classes (wrappers in this case) returns false
 
 


### PR DESCRIPTION
if this code snipped is put to the line 15 ..

Object o = moonLandingPrimitive;
System.out.println(o instanceof Short); // will give true